### PR TITLE
Fix a bug where particles got smaller on scroll.

### DIFF
--- a/src/shader.js
+++ b/src/shader.js
@@ -30,7 +30,7 @@ export default {
     "void main() {",
       "vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);",
       "vColor.xyz = getColor();",
-      "gl_PointSize = rZero * sqrt( log(1.0 - getAlpha()) / log(1.0 - alphaZero) ) * (100.0 / -mvPosition.z);",
+      "gl_PointSize = rZero * sqrt( log(1.0 - getAlpha()) / log(1.0 - alphaZero) ) * 10.0;",
       "gl_Position = projectionMatrix * mvPosition;",
 
     "}"


### PR DESCRIPTION
Now particle sizes won't be changed by camera position.
The number which I replaced with is a temporary value, so please let me know there's better one or simply replace it with new one.